### PR TITLE
Dual boot friendly (emulated) EEPROM management

### DIFF
--- a/src/hardware/eeprom_settings.cpp
+++ b/src/hardware/eeprom_settings.cpp
@@ -1,28 +1,30 @@
 #include "eeprom_settings.hpp"
 
+EEPROMClass  iArradio_EEPROM("iArradio", EEPROM_SIZE);
+
 void eeprom_init()
 {
-    EEPROM.begin(EEPROM_SIZE);
+    iArradio_EEPROM.begin(EEPROM_SIZE);
 }
 
 uint8_t eeprom_get_volume()
 {
-    return EEPROM.read(EEPROM_VOLUME_ADDRESS);
+    return iArradio_EEPROM.read(EEPROM_VOLUME_ADDRESS);
 }
 
 uint8_t eeprom_get_station()
 {
-    return EEPROM.read(EEPROM_STATION_ADDRESS);
+    return iArradio_EEPROM.read(EEPROM_STATION_ADDRESS);
 }
 
 void eeprom_set_volume(uint8_t vol)
 {
-    EEPROM.write(EEPROM_VOLUME_ADDRESS, vol);
-    EEPROM.commit();
+    iArradio_EEPROM.write(EEPROM_VOLUME_ADDRESS, vol);
+    iArradio_EEPROM.commit();
 }
 
 void eeprom_set_station(uint8_t sta)
 {
-    EEPROM.write(EEPROM_STATION_ADDRESS, sta);
-    EEPROM.commit();
+    iArradio_EEPROM.write(EEPROM_STATION_ADDRESS, sta);
+    iArradio_EEPROM.commit();
 }


### PR DESCRIPTION
&nbsp;&nbsp;&nbsp;&nbsp;Hello Rubén!

I am using your iArradio on T5S in 'dual boot' configuration: https://github.com/lyusupov/SoftRF/wiki/SkyView.-Dual-boot

On ESP32 the EEPROM area is emulated by main flash memory region.
When an application is alone - it is Ok, but when there are two of them - they overwrite each other's settings.

My proposal for you is to 'color' your application settings with a dedicated NVS key.
This way is simple, compatible, safe, sane and gives the necessary EEPROM separation effect.
The patch is attached to this pull request.

&nbsp;&nbsp;&nbsp;&nbsp;Best regards,
&nbsp;&nbsp;&nbsp;&nbsp;Linar.

